### PR TITLE
Sidebar to editor focus

### DIFF
--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -112,7 +112,7 @@ function Sidebar() {
               : currentIndex - 1;
           if (interactiveElements[prevIndex])
             interactiveElements[prevIndex].focus();
-        } else if (e.key === '/') {
+        } else if (e.ctrlKey && e.key === 'l') {
           e.preventDefault();
           if (editorRefs[activeTab]) {
             editorRefs[activeTab].focus();

--- a/src/renderer/components/Sidebar.tsx
+++ b/src/renderer/components/Sidebar.tsx
@@ -61,6 +61,9 @@ function Sidebar() {
   );
   const isEditing = useSelector((state: State) => state.workspace.isEditing);
   const containerRef = useRef<HTMLDivElement>(null);
+
+  const editorRefs = useSelector((state: State) => state.workspace.editorRefs);
+  const activeTab = useSelector((state: State) => state.tabBar.activeTabIndex);
   const dispatch = useDispatch();
 
   useEffect(() => {
@@ -109,6 +112,11 @@ function Sidebar() {
               : currentIndex - 1;
           if (interactiveElements[prevIndex])
             interactiveElements[prevIndex].focus();
+        } else if (e.key === '/') {
+          e.preventDefault();
+          if (editorRefs[activeTab]) {
+            editorRefs[activeTab].focus();
+          }
         }
       }
     };

--- a/src/renderer/components/markdown-editor.tsx
+++ b/src/renderer/components/markdown-editor.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
-import { setIsEditing } from '../store/reducers/workspace';
+import { setIsEditing, setEditorRefs } from '../store/reducers/workspace';
 import useCodemiror from '../utils/use-codemirror';
 
 type MarkdownEditorProps = {
@@ -25,7 +25,11 @@ function MarkdownEditor({
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if (editorView) markdownEditorRefs.current[index] = editorView;
+    if (editorView) {
+      markdownEditorRefs.current[index] = editorView;
+      // Store the markdownEditorRef in the redux store so that it can be used in the sidebar component (you store the refs in redux and also have a useRef, this is not optimal, might potentially be improved later)
+      dispatch(setEditorRefs(Array.from(markdownEditorRefs.current))); // might be causing the double rendering bug
+    }
   }, [editorView, index, markdownEditorRefs]);
 
   return (

--- a/src/renderer/store/index.ts
+++ b/src/renderer/store/index.ts
@@ -13,4 +13,7 @@ export default configureStore({
     workspace,
     tabBar,
   },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware({
+    serializableCheck: false
+  })
 });

--- a/src/renderer/store/reducers/workspace.ts
+++ b/src/renderer/store/reducers/workspace.ts
@@ -5,6 +5,7 @@ const initialState = {
   fileTree: [] as FileTree[],
   isEditing: false,
   allowFocusing: true,
+  editorRefs: null,
 };
 
 const workspaceSlice = createSlice({
@@ -23,10 +24,18 @@ const workspaceSlice = createSlice({
     setAllowFocusing: (state, action: PayloadAction<boolean>) => {
       state.allowFocusing = action.payload;
     },
+    setEditorRefs: (state, action) => {
+      state.editorRefs = action.payload;
+    },
   },
 });
 
-export const { setFileTree, toggleIsEditing, setIsEditing, setAllowFocusing } =
-  workspaceSlice.actions;
+export const {
+  setFileTree,
+  toggleIsEditing,
+  setIsEditing,
+  setAllowFocusing,
+  setEditorRefs,
+} = workspaceSlice.actions;
 
 export default workspaceSlice.reducer;

--- a/src/renderer/types/state.d.ts
+++ b/src/renderer/types/state.d.ts
@@ -15,6 +15,7 @@ export type State = {
     fileTree: FileTree[];
     isEditing: boolean;
     allowFocusing: boolean;
+    editorRefs: any[];
   };
   tabBar: {
     activeTabIndex: number;


### PR DESCRIPTION
Before, you could focus the sidebar from the markdown editor, now you can also focus the markdown editor from the sidebar.